### PR TITLE
Fix neynar client without API key

### DIFF
--- a/src/cannon.ts
+++ b/src/cannon.ts
@@ -6,19 +6,23 @@ import fetch from "node-fetch";
 import * as Sentry from "@sentry/node";
 
 export const fetchApprovedSigners = async (): Promise<Signer[]> => {
-	const endpoint = `${process.env.PUBLIC_URL}/allSigners`;
+        const endpoint = `${process.env.PUBLIC_URL}/allSigners`;
 
-	try {
-		const response = await fetch(endpoint);
-		const signers = await response.json();
+        try {
+                const response = await fetch(endpoint);
+                const signers = await response.json();
 
-		const approvedSigners = await Promise.all(
-			signers.map(async (signer: Signer) => {
-				if (signer.public_key) {
-					return await client.lookupDeveloperManagedSigner(signer.public_key);
-				}
-			}),
-		);
+                if (!client) {
+                        throw new Error("NEYNAR_API_KEY is missing");
+                }
+
+                const approvedSigners = await Promise.all(
+                        signers.map(async (signer: Signer) => {
+                                if (signer.public_key) {
+                                        return await client!.lookupDeveloperManagedSigner(signer.public_key);
+                                }
+                        }),
+                );
 
 		const filteredSigners = approvedSigners
 			.filter((signer) => {

--- a/src/neynar/client.ts
+++ b/src/neynar/client.ts
@@ -5,7 +5,13 @@ import { randomUUID } from "crypto";
 
 dotenv.config({ path: path.resolve(__dirname, "../../.env") });
 
-export const client = new NeynarAPIClient(process.env.NEYNAR_API_KEY || "");
+let client: NeynarAPIClient | undefined;
+
+if (process.env.NEYNAR_API_KEY) {
+  client = new NeynarAPIClient(process.env.NEYNAR_API_KEY);
+}
+
+export { client };
 
 export const postCastCannon = async (
   signerUuid: string,
@@ -14,11 +20,12 @@ export const postCastCannon = async (
 ) => {
   const idem = randomUUID();
 
+  if (!client) {
+    throw new Error("NEYNAR_API_KEY is missing");
+  }
+
   try {
-    await client.publishCast(signerUuid, text, {
-      replyTo: replyTo,
-      idem,
-    });
+    await client.publishCast(signerUuid, text, { replyTo, idem });
   } catch (error) {
     console.error("Error posting cast cannon:", error);
     throw error;


### PR DESCRIPTION
## Summary
- guard Neynar client initialization so missing API keys don't crash
- check for API key when fetching approved signers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591b49125c83218bff792e3f03011e